### PR TITLE
CMD Script clean-up

### DIFF
--- a/windows/service-install.bat
+++ b/windows/service-install.bat
@@ -1,21 +1,21 @@
-@SFC 2>&1 | FIND /i "/SCANNOW" >NUL
-@IF %ERRORLEVEL% NEQ 0 GOTO ELEVATE
-@GOTO ADMINTASKS
+@ECHO OFF & SETLOCAL ENABLEEXTENSIONS
+
+CD /d %~dp0
+SFC 2>&1 | FIND /i "/SCANNOW" >NUL:
+IF ERRORLEVEL 1 GOTO :ELEVATE
+GOTO :ADMINTASKS
 
 :ELEVATE
+
 ECHO Elevated privileges are temporarily required, just to register or remove the dnscrypt-proxy service
-CD /d %~dp0
 MSHTA "javascript: var shell = new ActiveXObject('shell.application'); shell.ShellExecute('%~nx0', '', '', 'runas', 1); close();"
 EXIT
 
 :ADMINTASKS
 
-@CD /d %~dp0
+dnscrypt-proxy.exe -service install
+dnscrypt-proxy.exe -service start
 
-.\dnscrypt-proxy.exe -service install
-.\dnscrypt-proxy.exe -service start
-
-@ECHO ""
-@SET /P _=Thank you for using dnscrypt-proxy! Hit [RETURN] to finish
-
+ECHO.
+SET /P _=Thank you for using dnscrypt-proxy! Hit [RETURN] to finish
 EXIT

--- a/windows/service-stop.bat
+++ b/windows/service-stop.bat
@@ -13,20 +13,7 @@ EXIT
 
 :ADMINTASKS
 
-REM If DNSCrypt-Proxy is not yet running restart will fail
-Tasklist /FI "IMAGENAME eq dnscrypt-proxy.exe" /NH | Find "dnscrypt-proxy.exe" >NUL:
-IF ERRORLEVEL 1 GOTO :SVCSTART
-
-ECHO Re-Starting Service...
-dnscrypt-proxy.exe -service restart
-GOTO :SAYTHANKS
-
-:SVCSTART
-
-ECHO Starting Service...
-dnscrypt-proxy.exe -service start
-
-:SAYTHANKS
+dnscrypt-proxy.exe -service stop
 
 ECHO.
 SET /P _=Thank you for using dnscrypt-proxy! Hit [RETURN] to finish

--- a/windows/service-uninstall.bat
+++ b/windows/service-uninstall.bat
@@ -1,21 +1,21 @@
-@SFC 2>&1 | FIND /i "/SCANNOW" >NUL
-@IF %ERRORLEVEL% NEQ 0 GOTO ELEVATE
-@GOTO ADMINTASKS
+@ECHO OFF & SETLOCAL ENABLEEXTENSIONS
+
+CD /d %~dp0
+SFC 2>&1 | FIND /i "/SCANNOW" >NUL:
+IF ERRORLEVEL 1 GOTO :ELEVATE
+GOTO :ADMINTASKS
 
 :ELEVATE
+
 ECHO Elevated privileges are temporarily required, just to register or remove the dnscrypt-proxy service
-CD /d %~dp0
 MSHTA "javascript: var shell = new ActiveXObject('shell.application'); shell.ShellExecute('%~nx0', '', '', 'runas', 1); close();"
 EXIT
 
 :ADMINTASKS
 
-@CD /d %~dp0
+dnscrypt-proxy.exe -service stop
+dnscrypt-proxy.exe -service uninstall
 
-.\dnscrypt-proxy.exe -service stop
-.\dnscrypt-proxy.exe -service uninstall
-
-@ECHO ""
-@SET /P _=Thank you for using dnscrypt-proxy! Hit [RETURN] to finish
-
+ECHO.
+SET /P _=Thank you for using dnscrypt-proxy! Hit [RETURN] to finish
 EXIT


### PR DESCRIPTION
RESTART now STARTS if the proxy is not already running.
Single call to CD instead of calling in two places.
IF ERRORLEVEL instead of using the pseudo-variable.
No need to specify DNSCrypt-Proxy.exe path since current directory searched first.
ECHO OFF & Enable Extensions.
ECHO. instead of echo'ing double quotes.
New Stop script